### PR TITLE
Fixing an error that would prevent the ProgressBar from hiding

### DIFF
--- a/packages/@uppy/progress-bar/src/index.js
+++ b/packages/@uppy/progress-bar/src/index.js
@@ -30,7 +30,7 @@ module.exports = class ProgressBar extends Plugin {
 
   render (state) {
     const progress = state.totalProgress || 0
-    // before starting and after finish should be hidden
+    // before starting and after finish should be hidden if specified in the options
     const isHidden = (progress === 0 || progress === 100) && this.opts.hideAfterFinish
     return (
       <div


### PR DESCRIPTION
`state.totalProgress` is not `100`. It's `0` instead   
----------

To reproduce the error:  
```
.use(ProgressBar, {
  target: '._progress_bar_',
  fixed: false,
  hideAfterFinish: true
})
```

This will set a `div` inside the `_progress_bar_` element, and this element will be visible, showing `0` to the user.

The problem is that, currently, the bar only hides when `progress === 100`, but that is never true, as `progress` resets to `0` once the upload has been completed.
That means, it is __always__ visible, and only hidden for a brief period after an upload completes (when the `progress === 100`, briefly).

This fix allows the bar to be hidden also when the progress is `0` (after and before uploads)